### PR TITLE
Update policies for better GDPR compliance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: go
 go:
-  - 1.5
+  - 1.10
 sudo: false
 install:
   - _bin/hugo.sh
@@ -12,8 +12,8 @@ cache:
   - vendor/bundle
 script:
  - bin/compass compile -e production --force
- - ~/hugo029 version
- - ~/hugo029
+ - ~/hugo version
+ - ~/hugo
  - ~/htmltest --version
  - ~/htmltest
 after_script:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,15 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.5)
-      i18n (~> 0.7)
-      json (~> 1.7, >= 1.7.7)
-      minitest (~> 5.1)
-      thread_safe (~> 0.3, >= 0.3.4)
-      tzinfo (~> 1.1)
-    addressable (2.4.0)
-    chunky_png (1.3.5)
-    colored (1.2)
+    chunky_png (1.3.10)
     compass (1.0.3)
       chunky_png (~> 1.2)
       compass-core (~> 1.0.2)
@@ -22,39 +14,14 @@ GEM
       sass (>= 3.3.0, < 3.5)
     compass-import-once (1.0.5)
       sass (>= 3.2, < 3.5)
-    ethon (0.8.0)
-      ffi (>= 1.3.0)
-    ffi (1.9.10)
-    html-proofer (2.6.1)
-      activesupport (~> 4.2)
-      addressable (~> 2.3)
-      colored (~> 1.2)
-      mercenary (~> 0.3.2)
-      nokogiri (~> 1.5)
-      parallel (~> 1.3)
-      typhoeus (~> 0.7)
-      yell (~> 2.0)
-    i18n (0.7.0)
-    json (1.8.3)
-    materialize-sass (0.97.3)
+    ffi (1.9.23)
+    materialize-sass (0.100.2)
       sass (~> 3.3)
-    mercenary (0.3.5)
-    mini_portile2 (2.0.0)
-    minitest (5.8.3)
-    multi_json (1.11.2)
-    nokogiri (1.6.7)
-      mini_portile2 (~> 2.0.0.rc2)
-    parallel (1.6.1)
-    rb-fsevent (0.9.6)
-    rb-inotify (0.9.5)
-      ffi (>= 0.5.0)
-    sass (3.4.20)
-    thread_safe (0.3.5)
-    typhoeus (0.8.0)
-      ethon (>= 0.8.0)
-    tzinfo (1.2.2)
-      thread_safe (~> 0.1)
-    yell (2.0.5)
+    multi_json (1.13.1)
+    rb-fsevent (0.10.3)
+    rb-inotify (0.9.10)
+      ffi (>= 0.5.0, < 2)
+    sass (3.4.25)
 
 PLATFORMS
   ruby
@@ -64,4 +31,4 @@ DEPENDENCIES
   materialize-sass
 
 BUNDLED WITH
-   1.11.1
+   1.16.1

--- a/_bin/htmltest.sh
+++ b/_bin/htmltest.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-curl -Lk https://github.com/wjdp/htmltest/releases/download/v0.4.1/htmltest-linux -o ~/htmltest && chmod +x "$_"
+curl -Lk https://github.com/wjdp/htmltest/releases/download/v0.9.1/htmltest_0.9.1_linux_amd64.tar.gz | tar xz -C ~ && chmod +x ~/htmltest
 exit 0

--- a/_bin/hugo.sh
+++ b/_bin/hugo.sh
@@ -1,6 +1,4 @@
 #!/bin/bash
 
-mkdir ~/hugo && cd "$_"
-curl -Lk https://github.com/spf13/hugo/releases/download/v0.29/hugo_0.29_Linux-64bit.tar.gz | tar xz
-mv hugo ~/hugo029 && chmod +x "$_"
+curl -Lk https://github.com/gohugoio/hugo/releases/download/v0.41/hugo_0.41_Linux-64bit.tar.gz | tar xz -C ~ && chmod +x ~/hugo
 exit 0

--- a/content/cookies.md
+++ b/content/cookies.md
@@ -10,7 +10,7 @@ You can think of cookies like stickers. Every time you visit a site, that site p
 That lets the site show you things which are relevant to you, based on information you’ve entered and stuff you’ve looked at. 
 The length of time stored depends on the cookie, but this is generally between a few minutes and up to two years.
 
-Cookies never store any of personal information.
+Cookies never store any personal information.
 
 We use a couple of different kinds of cookies:
 

--- a/content/cookies.md
+++ b/content/cookies.md
@@ -1,0 +1,26 @@
+---
+title: "TEC Cookie Policy"
+draft: true
+---
+
+Like most websites and apps, we use cookies. By using the TEC online services you agree to our use of cookies
+
+## Cookies help us remember your preferences
+You can think of cookies like stickers. Every time you visit a site, that site puts a sticker on you so they can keep track of how many times you’ve visited, how long you’ve spent there, and what you’ve done. 
+That lets the site show you things which are relevant to you, based on information you’ve entered and stuff you’ve looked at. 
+The length of time stored depends on the cookie, but this is generally between a few minutes and up to two years.
+
+Cookies never store any of personal information.
+
+We use a couple of different kinds of cookies:
+
+* ‘Session cookies’
+* ‘Persistent cookies’
+* ‘Third-party cookies’
+
+## Session and Persistent cookies track what you’re doing on a specific visit to our site
+We use session cookies to improve our site and give you a better experience. Session cookies let us see where you spend your time, and work out which bits are most (and least) effective. 
+Persistent cookies let us remember you on future visits, improving your experience of services or functions offered.
+
+## You can turn cookies off if you like
+Exactly how to do it depends on your browser or phone settings. Try looking in your ‘Help’ section, or searching for ‘How to block cookies’.

--- a/content/legal.md
+++ b/content/legal.md
@@ -21,20 +21,6 @@ Unauthorised use of this website may give rise to a claim for damages and/or be 
 From time to time this website may also include links to other websites. These links are provided for your convenience to provide further information. They do not signify that we endorse the website(s). We have no responsibility for the content of the linked website(s).
 Your use of this website and any dispute arising out of such use of the website is subject to the laws of England, Northern Ireland, Scotland and Wales.
 
-### Cookie Policy
-A cookie is a small file which asks permission to be placed on your computer’s hard drive. Once you agree, the file is added and the cookie helps analyse web traffic or lets you know when you visit a particular site. Cookies allow web applications to respond to you as an individual. The web application can tailor its operations to your needs, likes and dislikes by gathering and remembering information about your preferences.
-
-We use traffic log cookies to identify which pages are being used. This helps us analyse data about webpage traffic and improve our website in order to tailor it to customer needs. We only use this information for statistical analysis purposes and then the data is removed from the system.
-
-Overall, cookies help us provide you with a better website by enabling us to monitor which pages you find useful and which you do not. A cookie in no way gives us access to your computer or any information about you, other than the data you choose to share with us.
-
-You can choose to accept or decline cookies. Most web browsers automatically accept cookies, but you can usually modify your browser setting to decline cookies if you prefer. This may prevent you from taking full advantage of the website.
-
-Full details of TEC’s cookie usage can be found in our Website Terms and Conditions.
-
-## Copyright
-All website content &copy; TEC PA & Lighting. All rights reserved.
-
 ## Terms and Conditions of Service
 TEC PA & Lighting operates with the following [Terms of Hire](/terms.pdf) across all services.
 

--- a/content/privacy.md
+++ b/content/privacy.md
@@ -1,0 +1,93 @@
+---
+title: "TEC Privacy Policy"
+draft: true
+---
+
+## Who are we?
+We are TEC PA & Lighting (“we”, “our”, “us”), a Student Run Service of the University of Nottingham Students' Union.
+
+We provide high quality sound, lighting and audio-visual services both within the University of Nottingham Students’ Union and outside to public customers.
+
+We're committed to protecting and respecting your privacy. 
+If you have any questions about your personal information please email us at [info@nottinghamtec.co.uk](mailto:info@nottinghamtec.co.uk).
+
+We operate as a trading name of the University of Nottingham Students' Union, registered with the Information Commissioners Office under number Z2326680.
+
+
+## The information we hold about you
+
+* **Information you provide to us**
+<br>
+For example, when you contact us for an event and provide us with details such as your name, email address, phone number and venue details, we will record these to allow us to provide your event.
+<br>
+You may also provide us with contact details for your venue, we will save these for future events that may be held here.
+* **Details about your events**
+<br>
+We will need the start and end times for any event we provide.
+<br>
+There may also be times we need information about any acts performing at your event, including contact details for them.
+* **Membership details** 
+<br>
+If you are a TEC member, we will collect your student number from you and verify your membership status with the Students' Union.
+* **Information from social networks or online accounts**
+<br>
+Information from any accounts that you share with us.
+* **Cookie information**
+<br>
+Read our [Cookie Policy]({{< ref "cookies.md" >}}) for more info on what cookies are and how we use them.
+
+## How we use your information
+To provide our services. We use it to:
+
+* Contact you to organise and manage your event.
+* Invoice you or your company or society for our services.
+
+To meet our legal obligations. We use it to:
+* Prevent illegal activities like money laundering, tax evasion and fraud.
+
+To exercise what’s known as our legitimate interests. This is when we use data for a reason which is in your and/or our interest, and which doesn't involve overriding your privacy rights. We use it to:
+* Ask you for feedback on our services
+
+As a member. We use it to:
+* Keep you up to date with the latest events and other important information. You can opt out of this at any time by contacting us.
+
+## Who we share it with
+We may share your information with:
+
+* Any member who needs it to do their job.
+* Any organisation which supports any of our services you use, when they need it to offer those services. That includes:
+    * The University of Nottingham Students' Union Finance Office so they can manage our accounts. The Students' Union is also responsible for processing our invoices.
+    * The venue for your event should they need to contact you.
+    * Our suppliers where extra equipment is required.
+
+We’ll also share it to comply with the law; to enforce our Terms and Conditions or other agreements; or to protect the rights, property or safety of us, our customers or others.
+
+## How long we keep it
+We securely keep your data as long as you're using our services, and for 6 years after that to comply with the law.
+In some circumstances, like cases of fraud or legal investigations, we may keep data longer than we need to and/or the law says we have to.
+
+## Your rights
+You have a right to:
+
+* Access the personal data we hold about you, or to get a copy of it.
+* Make us correct inaccurate data.
+* Ask us to delete, 'block' or suppress your data, though for legal reasons we might not always be able to do it.
+* Object to us using your data for direct marketing and in certain circumstances ‘legitimate interests’, research and statistical reasons.
+* Withdraw any consent you’ve previously given us.
+
+To do so, please email us at [info@nottinghamtec.co.uk](mailto:info@nottinghamtec.co.uk).
+
+## Where we store your data
+We might transfer and store the data we collect from you somewhere outside the European Economic Area (‘EEA’). 
+People who work for us or our suppliers outside the EEA might also process your data. 
+We may share data with organisations and countries that:
+
+* The European Commission say have adequate data protection.
+* We’ve agreed standard data protection clauses with.
+
+## How to make a complaint
+If you have a complaint, please contact us by email at [info@nottinghamtec.co.uk](mailto:info@nottinghamtec.co.uk) and we'll do out best to fix the problem.
+If you still aren't happy, you can refer your complaint to the [University of Nottingham Students' Union](https://www.su.nottingham.ac.uk/).
+
+## Changes to this policy
+We’ll post any changes we make to our privacy notice on this page and, if they’re significant changes we may let you know by email.

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,107 +1,135 @@
-	<footer class="page-footer">
-		<div class="container">
-			<div class="row no-margin valign-wrapper">
-				<div class="col m4 l4 hide-on-small-and-down left-align">
-					<a href="/legal/">Legal</a>
-					&nbsp; &boxv; &nbsp;
-					<a href="https://members.nottinghamtec.co.uk">Members' Login</a>
-				</div>
+<footer class="page-footer">
+    <div class="container">
+        <div class="row no-margin">
+            <div class="col s12 m2 l1 brand-logo">
+                <img src="/imgs/tec_logo_white.png" alt="TEC PA &amp; Lighting">
+            </div>
+            <div class="col s12 m8">
+                <ul class="left">
+                    <li><a href="/legal/">Legal</a></li>
+                    <li><a href="/privacy/">Privacy Policy</a></li>
+                    <li><a href="/cookies/">Cookie Policy</a></li>
+                    <li><a href="https://members.nottinghamtec.co.uk">Members' Login</a></li>
+                </ul>
+            </div>
 
-				<div class="col s12 m4 l4 center-align">
-					&copy; TEC PA &amp; Lighting
-					<span class="hide-on-med-and-down">
-						&emsp;&emsp;
-						<!-- Social Media Icons-->
-						<a href="https://www.facebook.com/nottinghamtec"><i class="fa fa-facebook"></i></a>
-						&nbsp;
-						<a href="https://twitter.com/Nottingham_TEC"><i class="fa fa-twitter"></i></a>
-					</span>
-				</div>
-				<div class="col m3 hide-on-small-and-down">
-					<a href="http://su.nottingham.ac.uk/" rel="nofollow">
-						<img class="assoc-logo valign right" src="/imgs/UoNSU-small.png" alt="University of Nottingham Students' Union">
-					</a>
-				</div>
-				<div class="col m1 hide-on-small-and-down">
-					<a href="https://www.plasa.org/" rel="nofollow">
-						<img class="assoc-logo valign right" src="/imgs/plasa-small.png" alt="Plasa Member">
-					</a>
-				</div>
-			</div>
-		</div>
-	</footer>
+            <div class="col s12 m2 right center-on-small-only">
+                <div class="col s2 m6 offset-s4 center-on-small-only">
+                    <a href="http://su.nottingham.ac.uk/" rel="nofollow">
+                        <img class="assoc-logo valign right" src="/imgs/UoNSU-small.png"
+                             alt="University of Nottingham Students' Union">
+                    </a>
+                </div>
+                <div class="col s2 m6 center-on-small-only">
+                    <a href="https://www.plasa.org/" rel="nofollow">
+                        <img class="assoc-logo valign right" src="/imgs/plasa-small.png" alt="Plasa Member">
+                    </a>
+                </div>
+            </div>
+        </div>
+    </div>
+</footer>
 
-	<script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.97.1/js/materialize.min.js"></script>
+<script src="https://code.jquery.com/jquery-1.11.3.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/materialize/0.100.2/js/materialize.min.js"></script>
 
-	<script>
-	  (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-	  (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-	  m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-	  })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+<script>
+  (function (i, s, o, g, r, a, m) {
+    i['GoogleAnalyticsObject'] = r
+    i[r] = i[r] || function () {
+      (i[r].q = i[r].q || []).push(arguments)
+    }, i[r].l = 1 * new Date()
+    a = s.createElement(o),
+      m = s.getElementsByTagName(o)[0]
+    a.async = 1
+    a.src = g
+    m.parentNode.insertBefore(a, m)
+  })(window, document, 'script', '//www.google-analytics.com/analytics.js', 'ga')
 
-	  ga('create', 'UA-43285686-10', 'auto');
-	  ga('send', 'pageview');
+  ga('create', 'UA-43285686-10', 'auto')
+  ga('send', 'pageview')
 
+</script>
+
+<script>
+    function pinToc() {
+      // Floating-Fixed table of contents
+      let hTop, hBot;
+
+      if ($('header').length) {
+        hTop = $('header').height();
+      }
+      else if ($('#index-banner').length) {
+        hTop = $('#index-banner').height();
+      }
+      else {
+        hTop = 0;
+      }
+
+      if ($('footer').length) {
+        hBot = $('footer').height();
+      } else {
+        hBot = 0;
+      }
+
+      $('.toc-wrapper').each(function() {
+        let $this = $(this);
+        $this.pushpin('remove');
+        hBot = $('main').outerHeight() + hTop - $this.parent().height();
+        $this.pushpin({
+          top: hTop,
+          bottom: hBot,
+        })
+      });
+    }
+
+    $(window).load(pinToc);
+
+    $(window).resize(pinToc);
+
+    // Plugin initialization
+    $('.slider').slider({full_width: true});
+    $('.parallax').parallax();
+    $('.modal-trigger').modal();
+    $('.scrollspy').scrollSpy();
+    $('.button-collapse').sideNav({'edge': 'left'});
+    $('.datepicker').pickadate({selectYears: 20});
+    $('select').not('.disabled').material_select();
 	</script>
 
-	<script>
-		$(document).ready(function() {
-			// Floating-Fixed table of contents
-		    if ($('header').length) {
-		      $('.toc-wrapper').pushpin({ top: $('header').height() });
-		    }
-		    else if ($('#index-banner').length) {
-		      $('.toc-wrapper').pushpin({ top: $('#index-banner').height() });
-		    }
-		    else {
-		      $('.toc-wrapper').pushpin({ top: 0 });
-		    }
-		})
+<script>
+  $(document).ready(function () {
+    var offset = 300 // How far down does the button show
+    var offset_opacity = 700 // How far down does the opacity reduce
+    var scroll_top_duration = 700 // Duration of animation
 
-		// Plugin initialization
-	    $('.slider').slider({full_width: true});
-	    $('.parallax').parallax();
-	    $('.modal-trigger').leanModal();
-	    $('.scrollspy').scrollSpy();
-	    $('.button-collapse').sideNav({'edge': 'left'});
-	    $('.datepicker').pickadate({selectYears: 20});
-	    $('select').not('.disabled').material_select();
-	</script>
+    $back_to_top = $('.to-top') // Button class
 
-	<script>
-		$(document).ready(function(){
-			var offset = 300; // How far down does the button show
-			var offset_opacity = 700; // How far down does the opacity reduce
-			var scroll_top_duration = 700; // Duration of animation
+    $(window).scroll(function () {
+      if ($(this).scrollTop() > offset) {
+        $back_to_top.addClass('visible')
+      } else {
+        $back_to_top.removeClass('visible fade-out hover')
+      }
+      if ($(this).scrollTop() > offset_opacity) {
+        $back_to_top.addClass('fade-out')
+      }
+    })
 
-			$back_to_top = $('.to-top'); // Button class
+    // Capture screen presses on touch devices
+    $back_to_top.on('click touchstart', function () {
+      $back_to_top.addClass('hover')
+    })
 
-			$(window).scroll(function(){
-				if( $(this).scrollTop() > offset ) {
-					$back_to_top.addClass('visible') 
-				} else {
-					$back_to_top.removeClass('visible fade-out hover');
-				}
-				if( $(this).scrollTop() > offset_opacity ) { 
-					$back_to_top.addClass('fade-out');
-				}
-			});
-
-			// Capture screen presses on touch devices
-			$back_to_top.on('click touchstart', function() {
-				$back_to_top.addClass('hover');
-			});
-
-			// Smooth (criminal) scroll to top
-			$back_to_top.on('click', function(event){
-				event.preventDefault();
-				$('body,html').animate({
-					scrollTop: 0 ,
-				 	}, scroll_top_duration
-				);
-			});
-		});
-	</script>
+    // Smooth (criminal) scroll to top
+    $back_to_top.on('click', function (event) {
+      event.preventDefault()
+      $('body,html').animate({
+          scrollTop: 0,
+        }, scroll_top_duration
+      )
+    })
+  })
+</script>
 </body>
 </html>

--- a/src/sass/screen.scss
+++ b/src/sass/screen.scss
@@ -1,8 +1,6 @@
 @import "compass";
 
 // Mixins
-@import "materialize/components/prefixer";
-@import "materialize/components/mixins";
 @import "materialize/components/color";
 
 $primary-color: color("grey", "darken-4");

--- a/src/sass/screen.scss
+++ b/src/sass/screen.scss
@@ -39,6 +39,20 @@ body {
   .assoc-logo {
     max-height: 2rem;
   }
+
+  .brand-logo {
+    img {
+      max-width: 100%;
+      max-height: 5rem;
+    }
+  }
+
+  @media #{$medium-and-up} {
+    .row {
+      display: flex;
+      align-items: center;
+    }
+  }
 }
 
 $main-nav-top: 3rem;
@@ -150,11 +164,11 @@ $main-nav-height: 6rem;
 }
 
 article {
-  ul {
+  ul, ul:not(.browser-default)  {
     list-style-type: square;
     padding-left: 1.5rem;
 
-    li {
+    & > li {
       list-style-type: square;
     }
   }


### PR DESCRIPTION
Provide a Monzo inspired privacy and cookie policy to brings is more in line with GDPR.

Required some reworking of the footer to add the links and make it still look decent.

Privacy has a reading ease score of 61.8, cookies 67, SU's privacy policy comes in at 42.9 (higher is easier to read).

Request for comments and proof reading please. 

Also updates versions of things to the latest stable version.